### PR TITLE
Timescale for seek method fix

### DIFF
--- a/NPAudioStream.podspec
+++ b/NPAudioStream.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
 
   s.public_header_files = 'NPAudioStream/*.h'
   s.source_files = 'NPAudioStream/NPAudioStream.{h,m}', 'NPAudioStream/NPQueuePlayer.{h,m}', 'NPAudioStream/NPPlayerItem.{h,m}', 'NPAudioStream/Categories/NSURL+Extensions.{h,m}', 'NPAudioStream/Categories/NSMutableArray+Extensions.{h,m}'
-  s.ios.source_files = 'NPAudioStream/Categories/UIAlertView+Extensions.{h,m}'
+  s.ios.source_files = 'NPAudioStream/Categories/*.{h,m}'
   s.frameworks = 'AVFoundation'
 end

--- a/NPAudioStream/NPAudioStream.m
+++ b/NPAudioStream/NPAudioStream.m
@@ -167,7 +167,7 @@ NSString *kDurationKey          = @"duration";
     
     [self removeTimeObservers];
     
-    int32_t timeScale = _player.currentItem.asset.duration.timescale;
+    int32_t timeScale = _player.currentItem.asset.duration.timescale ? _player.currentItem.asset.duration.timescale : 1;
     CMTime time = CMTimeMakeWithSeconds(seconds, timeScale);
     
     [_player seekToTime:time


### PR DESCRIPTION
Hi guys,

Great library! Only issue I faced was that the asset I was using doesn't return a duration as it's a URL stream, so the `timeScale` was `nil` and it was crashing the app. This loads a default value for `timeScale` which keeps everything working.

Cheers,
G